### PR TITLE
Fix travis build

### DIFF
--- a/run_cookiecutter_tests.sh
+++ b/run_cookiecutter_tests.sh
@@ -18,12 +18,12 @@ docker-compose -f travis-docker-compose.yml rm -f
 docker-compose -f travis-docker-compose.yml build --no-cache
 
 docker-compose -f travis-docker-compose.yml run web tox
-docker-compose run watch yarn install
-docker-compose run watch npm run-script coverage
-docker-compose run watch npm run-script lint
-docker-compose run watch npm run-script flow
+docker-compose -f travis-docker-compose.yml run watch yarn install
+docker-compose -f travis-docker-compose.yml run watch npm run coverage
+docker-compose -f travis-docker-compose.yml run watch npm run lint
+docker-compose -f travis-docker-compose.yml run watch npm run flow
 
 # Also make sure webpack runs successfully
-docker-compose run watch ./webpack_if_prod.sh
+docker-compose -f travis-docker-compose.yml run watch ./webpack_if_prod.sh
 
 echo "Success!"

--- a/run_cookiecutter_tests.sh
+++ b/run_cookiecutter_tests.sh
@@ -18,12 +18,8 @@ docker-compose -f travis-docker-compose.yml rm -f
 docker-compose -f travis-docker-compose.yml build --no-cache
 
 docker-compose -f travis-docker-compose.yml run web tox
-docker-compose -f travis-docker-compose.yml run watch yarn install
-docker-compose -f travis-docker-compose.yml run watch npm run coverage
-docker-compose -f travis-docker-compose.yml run watch npm run lint
-docker-compose -f travis-docker-compose.yml run watch npm run flow
 
-# Also make sure webpack runs successfully
-docker-compose -f travis-docker-compose.yml run watch ./webpack_if_prod.sh
+docker build -t travis-watch -f ./Dockerfile-node .
+docker run travis-watch bash ./travis/js_tests.sh
 
 echo "Success!"

--- a/run_cookiecutter_tests.sh
+++ b/run_cookiecutter_tests.sh
@@ -19,9 +19,7 @@ docker-compose -f travis-docker-compose.yml build --no-cache
 
 docker-compose -f travis-docker-compose.yml run web tox
 
-# Copy over travis/js_tests.sh so it gets included in the Dockerfile
-cp -v ./travis/js_tests.sh ./scripts/
-docker build --no-cache -t cookiecutter-test-travis-watch -f ./Dockerfile-node .
-docker run cookiecutter-test-travis-watch /src/scripts/js_tests.sh
+docker build --no-cache -t travis-watch -f ./Dockerfile-node .
+./travis/js_tests.sh
 
 echo "Success!"

--- a/run_cookiecutter_tests.sh
+++ b/run_cookiecutter_tests.sh
@@ -20,6 +20,8 @@ docker-compose -f travis-docker-compose.yml build --no-cache
 
 docker-compose -f travis-docker-compose.yml run web tox
 
+# Make a fake lock file to avoid a COPY failure in the Dockerfile
+touch yarn.lock
 docker build --no-cache -f ./travis/Dockerfile-travis-watch-build -t mitodl/${PROJECT_NAME}_watch_travis .
 docker build --no-cache -f ./travis/Dockerfile-travis-watch -t travis-watch .
 ./travis/js_tests.sh

--- a/run_cookiecutter_tests.sh
+++ b/run_cookiecutter_tests.sh
@@ -4,7 +4,8 @@ set -euf -o pipefail
 export TEMPDIR="$(mktemp -d)"
 cookiecutter . -o "$TEMPDIR" --no-input
 
-export TOXINI_DIR=$(find "$TEMPDIR" -name tox.ini -printf '%h\n')
+export TOXINI_DIR="$(find "$TEMPDIR" -name tox.ini -printf '%h\n')"
+export PROJECT_NAME="$(basename "$TOXINI_DIR")"
 cd "$TOXINI_DIR"
 cp "$TOXINI_DIR"/.env.example "$TOXINI_DIR"/.env
 pip-compile
@@ -19,7 +20,8 @@ docker-compose -f travis-docker-compose.yml build --no-cache
 
 docker-compose -f travis-docker-compose.yml run web tox
 
-docker build --no-cache -t travis-watch -f ./Dockerfile-node .
+docker build --no-cache -f ./travis/Dockerfile-travis-watch-build -t mitodl/${PROJECT_NAME}_watch_travis .
+docker build --no-cache -f ./travis/Dockerfile-travis-watch -t travis-watch .
 ./travis/js_tests.sh
 
 echo "Success!"

--- a/run_cookiecutter_tests.sh
+++ b/run_cookiecutter_tests.sh
@@ -19,7 +19,9 @@ docker-compose -f travis-docker-compose.yml build --no-cache
 
 docker-compose -f travis-docker-compose.yml run web tox
 
-docker build -t travis-watch -f ./Dockerfile-node .
-docker run travis-watch bash ./travis/js_tests.sh
+# Copy over travis/js_tests.sh so it gets included in the Dockerfile
+cp -v ./travis/js_tests.sh ./scripts/
+docker build --no-cache -t cookiecutter-test-travis-watch -f ./Dockerfile-node .
+docker run cookiecutter-test-travis-watch /src/scripts/js_tests.sh
 
 echo "Success!"


### PR DESCRIPTION
Fixes the travis build. Instead of using `docker-compose` with the watch container, this builds the travis docker image similar to how it's done in `.travis.yml`