### PR TITLE
Use yarn install --frozen-lockfile to detect yarn.lock errors

### DIFF
--- a/run_cookiecutter_tests.sh
+++ b/run_cookiecutter_tests.sh
@@ -20,8 +20,8 @@ docker-compose -f travis-docker-compose.yml build --no-cache
 
 docker-compose -f travis-docker-compose.yml run web tox
 
-# Make a fake lock file to avoid a COPY failure in the Dockerfile
-touch yarn.lock
+# Make a lock file to avoid a COPY failure in the Dockerfile
+yarn install
 docker build --no-cache -f ./travis/Dockerfile-travis-watch-build -t mitodl/${PROJECT_NAME}_watch_travis .
 docker build --no-cache -f ./travis/Dockerfile-travis-watch -t travis-watch .
 ./travis/js_tests.sh

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -120,5 +120,5 @@ Note that running [`flow`](https://flowtype.org) may not work properly if your
 host machine isn't running Linux. If you are using a Mac, you'll need to run
 `flow` on your host machine, like this:
 
-    yarn install --pure-lockfile
+    yarn install --frozen-lockfile
     npm run-script flow

--- a/{{ cookiecutter.project_name }}/travis/Dockerfile-travis-watch
+++ b/{{ cookiecutter.project_name }}/travis/Dockerfile-travis-watch
@@ -10,7 +10,7 @@ ADD ./webpack_if_prod.sh /src
 
 USER node
 
-RUN yarn install --pure-lockfile
+RUN yarn install --frozen-lockfile
 
 COPY . /src
 

--- a/{{ cookiecutter.project_name }}/travis/Dockerfile-travis-watch-build
+++ b/{{ cookiecutter.project_name }}/travis/Dockerfile-travis-watch-build
@@ -23,6 +23,6 @@ USER node
 
 # this is just to get a warm cache, we delete node_modules afterwards to
 # avoid issues with native extensions (mainly node-sass)
-RUN yarn install --pure-lockfile
+RUN yarn install --frozen-lockfile
 
 RUN rm -rf node_modules

--- a/{{ cookiecutter.project_name }}/webpack_dev_server.sh
+++ b/{{ cookiecutter.project_name }}/webpack_dev_server.sh
@@ -17,7 +17,7 @@ if [[ "$IS_OSX" == "true" && "$INSIDE_CONTAINER" == "true" ]] ; then
   echo -e "EXITING WEBPACK STARTUP SCRIPT\nOSX Users: The webpack dev server should be run on your host machine."
 else
   if [[ "$1" == "--install" ]] ; then
-    yarn install --pure-lockfile && echo "Finished yarn install"
+    yarn install --frozen-lockfile && echo "Finished yarn install"
   fi
   # Start the webpack dev server on the appropriate host and port
   node ./hot-reload-dev-server.js --host "$WEBPACK_HOST" --port "$WEBPACK_PORT"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/issues/3651

#### What's this PR do?
Uses `yarn install --frozen-lockfile` which errors if an upgrade is needed

#### How should this be manually tested?
N/A
