### PR TITLE
Add check_pip.sh

### DIFF
--- a/{{ cookiecutter.project_name }}/scripts/test/check_pip.sh
+++ b/{{ cookiecutter.project_name }}/scripts/test/check_pip.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 set -e -o pipefail
 

--- a/{{ cookiecutter.project_name }}/scripts/test/check_pip.sh
+++ b/{{ cookiecutter.project_name }}/scripts/test/check_pip.sh
@@ -1,0 +1,21 @@
+
+#!/usr/bin/env bash
+set -e -o pipefail
+
+PIP_OLD=$(mktemp)
+PIP_NEW=$(mktemp)
+VENV=$(mktemp -d)
+
+
+pip freeze > $PIP_NEW
+/usr/local/bin/pip freeze > $PIP_OLD
+if ! cmp -s $PIP_OLD $PIP_NEW
+then
+  echo "requirements files differ from docker image pip environment. Running diff image-pip tox-pip:"
+  diff $PIP_OLD $PIP_NEW
+  exit 1
+fi
+
+rm $PIP_OLD
+rm $PIP_NEW
+rm -r $VENV

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -9,6 +9,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 commands =
+    {toxinidir}/scripts/test/check_pip.sh
     py.test {posargs}
     {toxinidir}/travis/codecov_python.sh
     {toxinidir}/scripts/test/detect_missing_migrations.sh


### PR DESCRIPTION
Fixes #122 

This adds a check which validates that the current docker image contains the same set of requirements as specified in the requirements files