### PR TITLE
Error if Python interpreter is not present for tests

### DIFF
--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py36
-skip_missing_interpreters = True
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Having `skip_missing_interpreters = True` will make the tests pass if python 3.6 doesn't exist. Since we only support one python version at a time we should fail in that case so that the end user knows to install the missing python version