### PR TITLE
Use the passed port instead of hardcoded one for devserver

### DIFF
--- a/{{ cookiecutter.project_name }}/hot-reload-dev-server.js
+++ b/{{ cookiecutter.project_name }}/hot-reload-dev-server.js
@@ -26,7 +26,7 @@ app.use(devMiddleware(compiler, {
 
 app.use(hotMiddleware(compiler));
 
-app.listen({{ cookiecutter.webpack_dev_port }}, (err) => {
+app.listen(port, (err) => {
   if (err) {
     return console.error(err)
   }


### PR DESCRIPTION
The script accepts and completely ignores the passed port. To make matters worse, it incorrectly reports it bound to the passed port.