### PR TITLE
Fix typo in uWSGI parameter

### DIFF
--- a/{{ cookiecutter.project_name }}/uwsgi.ini
+++ b/{{ cookiecutter.project_name }}/uwsgi.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 strict = true
 need-app = true
-py-callos-afterfork = true
+py-call-osafterfork = true
 auto-procname = true
 if-env = DEV_ENV
 socket = :$(PORT)


### PR DESCRIPTION
Fix misnamed parameter: change "py-callos-afterfork" to
"py-call-osafterfork".

See https://www.techatbloomberg.com/blog/configuring-uwsgi-production-deployment/
See https://github.com/mitodl/salt-ops/commit/850f8cc17cfcc65af47f63e1cc40f81cb718f2c3

The salt-ops fix above has been tested.