### PR TITLE
Remove py-call-osafterfork uWSGI setting

### DIFF
--- a/{{ cookiecutter.project_name }}/uwsgi.ini
+++ b/{{ cookiecutter.project_name }}/uwsgi.ini
@@ -1,7 +1,6 @@
 [uwsgi]
 strict = true
 need-app = true
-py-call-osafterfork = true
 auto-procname = true
 if-env = DEV_ENV
 socket = :$(PORT)


### PR DESCRIPTION
Remove py-call-osafterfork directive from uwsgi.ini. Due to buggy
behavior in uWSGI, this causes an exception on startup when running on
some versions of Python 3. The setting will be deprecated or silently ignored when the necxt version of uWSGI is released. The `py-call-osafterfork = true` behavior will become the default in that release.

See
https://github.com/mitodl/micromasters/pull/4569#issuecomment-611130601
and other comments and links in that thread.