### PR TITLE
Handle static/hash.txt before generic static nginx rule

### DIFF
--- a/{{ cookiecutter.project_name }}/config/nginx.conf.erb
+++ b/{{ cookiecutter.project_name }}/config/nginx.conf.erb
@@ -47,15 +47,15 @@ http {
             try_files /static/images/favicon.ico /favicon.ico;
         }
 
+        location ~* /static/hash.txt {
+            expires -1;
+            add_header Cache-Control private;
+        }
+
         location ~* /static/(.*$) {
             expires max;
             add_header Access-Control-Allow-Origin *;
             try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
-        }
-
-        location ~* /static/hash.txt {
-            expires -1;
-            add_header Cache-Control private;
         }
 
         location / {


### PR DESCRIPTION
Fixes #169 