### PR TITLE
Add middleware for cache-control headers for API endpoints

### DIFF
--- a/{{ cookiecutter.project_name }}/main/middleware.py
+++ b/{{ cookiecutter.project_name }}/main/middleware.py
@@ -117,3 +117,13 @@ class CookieFeatureFlagMiddleware(MiddlewareMixin):
             request (django.http.request.Request): the request to inspect
         """
         request.{{ cookiecutter.project_name }}_feature_flags = self.get_feature_flags(request)
+
+
+class CachelessAPIMiddleware(MiddlewareMixin):
+    """ Add Cache-Control header to API responses"""
+
+    def process_response(self, request, response):
+        """ Add a Cache-Control header to an API response """
+        if request.path.startswith("/api/"):
+            response["Cache-Control"] = "private, no-store"
+        return response

--- a/{{ cookiecutter.project_name }}/main/middleware_test.py
+++ b/{{ cookiecutter.project_name }}/main/middleware_test.py
@@ -5,12 +5,15 @@ from unittest.mock import (
 )
 
 import ddt
+from django.urls import reverse
 from django.test import (
     override_settings,
     TestCase,
 )
+import pytest
 
 from main.middleware import (
+    CachelessAPIMiddleware,
     CookieFeatureFlagMiddleware,
     QueryStringFeatureFlagMiddleware,
 )
@@ -125,3 +128,17 @@ class CookieFeatureFlagMiddlewareTest(TestCase):
         assert self.middleware.process_request(request) is None
         request.get_signed_cookie.assert_not_called()
         assert request.{{ cookiecutter.project_name }}_feature_flags == set()
+
+
+@pytest.mark.parametrize(
+    "view, cache_value",
+    [["applications", None], ["applications_api-list", "private, no-store"]],
+)
+def test_cacheless_api_middleware(rf, view, cache_value):
+    """Tests that the response has a cache-control header for API URLs"""
+    request = rf.get(reverse(view))
+    middleware = CachelessAPIMiddleware()
+    assert (
+        middleware.process_response(request, {}).get("Cache-Control", None)
+        == cache_value
+    )

--- a/{{ cookiecutter.project_name }}/main/middleware_test.py
+++ b/{{ cookiecutter.project_name }}/main/middleware_test.py
@@ -5,12 +5,10 @@ from unittest.mock import (
 )
 
 import ddt
-from django.urls import reverse
 from django.test import (
     override_settings,
     TestCase,
 )
-import pytest
 
 from main.middleware import (
     CookieFeatureFlagMiddleware,

--- a/{{ cookiecutter.project_name }}/main/middleware_test.py
+++ b/{{ cookiecutter.project_name }}/main/middleware_test.py
@@ -13,7 +13,6 @@ from django.test import (
 import pytest
 
 from main.middleware import (
-    CachelessAPIMiddleware,
     CookieFeatureFlagMiddleware,
     QueryStringFeatureFlagMiddleware,
 )
@@ -128,17 +127,3 @@ class CookieFeatureFlagMiddlewareTest(TestCase):
         assert self.middleware.process_request(request) is None
         request.get_signed_cookie.assert_not_called()
         assert request.{{ cookiecutter.project_name }}_feature_flags == set()
-
-
-@pytest.mark.parametrize(
-    "view, cache_value",
-    [["applications", None], ["applications_api-list", "private, no-store"]],
-)
-def test_cacheless_api_middleware(rf, view, cache_value):
-    """Tests that the response has a cache-control header for API URLs"""
-    request = rf.get(reverse(view))
-    middleware = CachelessAPIMiddleware()
-    assert (
-        middleware.process_response(request, {}).get("Cache-Control", None)
-        == cache_value
-    )

--- a/{{ cookiecutter.project_name }}/main/settings.py
+++ b/{{ cookiecutter.project_name }}/main/settings.py
@@ -104,7 +104,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     "django.contrib.sites.middleware.CurrentSiteMiddleware",
-    "{{ cookiecutter.project_name }}.middleware.CachelessAPIMiddleware",
+    "main.middleware.CachelessAPIMiddleware",
 )
 
 # enable the nplusone profiler only in debug mode

--- a/{{ cookiecutter.project_name }}/main/settings.py
+++ b/{{ cookiecutter.project_name }}/main/settings.py
@@ -104,6 +104,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     "django.contrib.sites.middleware.CurrentSiteMiddleware",
+    "{{ cookiecutter.project_name }}.middleware.CachelessAPIMiddleware",
 )
 
 # enable the nplusone profiler only in debug mode


### PR DESCRIPTION
Fixes #171 