### PR TITLE
pgbouncer stunnel is deprecated

### DIFF
--- a/{{ cookiecutter.project_name }}/Procfile
+++ b/{{ cookiecutter.project_name }}/Procfile
@@ -1,3 +1,3 @@
-web: bin/start-nginx bin/start-pgbouncer-stunnel newrelic-admin run-program uwsgi uwsgi.ini
+web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
 worker: bin/start-pgbouncer newrelic-admin run-program celery -A main.celery:app worker -B -l ${{ cookiecutter.project_name|upper }}_LOG_LEVEL
 extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A main.celery:app worker -l ${{ cookiecutter.project_name|upper }}_LOG_LEVEL


### PR DESCRIPTION
This updates the pgbouncer command for future uses of the cookie-cutter.